### PR TITLE
Provide an (optional) cache for block definitions on list block, stream block, and struct block

### DIFF
--- a/wagtail_react_streamfield/blocks/block.py
+++ b/wagtail_react_streamfield/blocks/block.py
@@ -21,8 +21,9 @@ def get_cache_sig(block, **kwargs):
     parent_block = kwargs.get('parent_block')
     help_text = getattr(block.meta, 'help_text', None)
     icon = getattr(block.meta, 'icon', None)
-    return (block.name, icon, help_text, type(block), type(parent_block)) if parent_block \
-        else (block.name, icon, help_text, type(block))
+    group = getattr(block.meta, 'group', None)
+    return (type(block), type(parent_block), block.name, icon, help_text, group) if parent_block \
+        else (type(block), block.name, icon, help_text, group)
 
 
 class NewBlock(Block):
@@ -46,8 +47,6 @@ class NewBlock(Block):
             value = value.value
         else:
             block_id = str(uuid4())
-        
-        logger.debug('Retrieve value for %s (%s): %s' % (block_id, type(self), datetime.datetime.utcnow()))
         
         value = self.prepare_value(value, errors=errors)
         if parent_block is None:

--- a/wagtail_react_streamfield/blocks/block.py
+++ b/wagtail_react_streamfield/blocks/block.py
@@ -11,8 +11,6 @@ from wagtail_react_streamfield.widgets import BlockData, get_non_block_errors
 logger = logging.getLogger(__name__)
 
 
-BLOCK_CACHE = {}
-
 def get_cache_sig(block, **kwargs):
     ''' Determine an appropriate cache signature that takes into account the block,
         the parent block, and the help text.
@@ -74,12 +72,11 @@ class NewBlock(Block):
     def get_definition(self, *args, **kwargs):
 
         # Check cache for rendered definition of the block
-        csig = get_cache_sig(self, **kwargs)
-        if BLOCK_CACHE.get(csig):
-            return BLOCK_CACHE.get(csig)
-        
-        logger.debug('Prepare definition of stream field block %s (%s): %s' 
-            % (self.name, type(self), datetime.datetime.utcnow()))
+        if hasattr(self, 'block_cache'):
+            logger.debug('Get block from cache: %s (%s)' % (self.name, type(self)))
+            csig = get_cache_sig(self, **kwargs)
+            if self.block_cache.get(csig):
+                return self.block_cache.get(csig)
 
         definition = {
             'key': self.name,
@@ -98,7 +95,9 @@ class NewBlock(Block):
             definition['default'] = self.prepare_value(self.get_default())
 
         # Cache definition of block
-        BLOCK_CACHE[csig] = definition
+        if hasattr(self, 'block_cache'):
+            self.block_cache[csig] = definition
+
         return definition
 
     def all_html_declarations(self):

--- a/wagtail_react_streamfield/blocks/block.py
+++ b/wagtail_react_streamfield/blocks/block.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from django.template.loader import render_to_string
 from django.utils.text import capfirst
-from wagtail.core.blocks import Block, StreamValue, RichTextBlock, PageChooserBlock
+from wagtail.core.blocks import Block, StreamValue, StreamBlock, RichTextBlock, PageChooserBlock
 
 from wagtail_react_streamfield.exceptions import RemovedError
 from wagtail_react_streamfield.widgets import BlockData, get_non_block_errors
@@ -32,6 +32,10 @@ def get_cache_sig(block, **kwargs):
     # For PageChooserBlock add the page types to the signature
     elif isinstance(block, PageChooserBlock) and getattr(block, 'target_model', None):
         csig = csig + (tuple(block.target_model) if isinstance(block.target_model, (tuple, list)) else (block.target_model,))
+
+    # For stream blocks, ensure that the number of child blocks is taken into account
+    elif isinstance(block, StreamBlock):
+        csig = csig + (len(block.dependencies),)
     
     return csig
 

--- a/wagtail_react_streamfield/blocks/block.py
+++ b/wagtail_react_streamfield/blocks/block.py
@@ -17,11 +17,12 @@ def get_cache_sig(block, **kwargs):
     ''' Determine an appropriate cache signature that takes into account the block,
         the parent block, and the help text.
     '''
+    # Retrieve parent block, help text, and icon from block attributes
     parent_block = kwargs.get('parent_block')
     help_text = getattr(block.meta, 'help_text', None)
     icon = getattr(block.meta, 'icon', None)
-    return (block.name, type(parent_block), type(block), icon, help_text) if parent_block \
-        else (block.name, type(block), icon, help_text)
+    return (block.name, icon, help_text, type(block), type(parent_block)) if parent_block \
+        else (block.name, icon, help_text, type(block))
 
 
 class NewBlock(Block):
@@ -89,8 +90,7 @@ class NewBlock(Block):
             'dangerouslyRunInnerScripts': True,
         }
         if self.meta.icon != Block._meta_class.icon:
-            definition['icon'] = ('<i class="icon icon-%s"></i>'
-                                  % self.meta.icon)
+            definition['icon'] = ('<i class="icon icon-%s"></i>' % self.meta.icon)
         if self.meta.classname is not None:
             definition['className'] = self.meta.classname
         if self.meta.group:

--- a/wagtail_react_streamfield/blocks/block.py
+++ b/wagtail_react_streamfield/blocks/block.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from django.template.loader import render_to_string
 from django.utils.text import capfirst
-from wagtail.core.blocks import Block, StreamValue
+from wagtail.core.blocks import Block, StreamValue, RichTextBlock
 
 from wagtail_react_streamfield.exceptions import RemovedError
 from wagtail_react_streamfield.widgets import BlockData, get_non_block_errors
@@ -20,8 +20,16 @@ def get_cache_sig(block, **kwargs):
     help_text = getattr(block.meta, 'help_text', None)
     icon = getattr(block.meta, 'icon', None)
     group = getattr(block.meta, 'group', None)
-    return (type(block), type(parent_block), block.name, icon, help_text, group) if parent_block \
+
+    # Create signature from block ,parent block, icon, and features
+    csig = (type(block), type(parent_block), block.name, icon, help_text, group) if parent_block \
         else (type(block), block.name, icon, help_text, group)
+
+    # For RichTextBlock add the features to the signature
+    if isinstance(block, RichTextBlock) and getattr(block, 'features', None):
+        csig = csig + (tuple(block.features),)
+    
+    return csig
 
 
 class NewBlock(Block):

--- a/wagtail_react_streamfield/blocks/block.py
+++ b/wagtail_react_streamfield/blocks/block.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from django.template.loader import render_to_string
 from django.utils.text import capfirst
-from wagtail.core.blocks import Block, StreamValue, RichTextBlock
+from wagtail.core.blocks import Block, StreamValue, RichTextBlock, PageChooserBlock
 
 from wagtail_react_streamfield.exceptions import RemovedError
 from wagtail_react_streamfield.widgets import BlockData, get_non_block_errors
@@ -28,6 +28,10 @@ def get_cache_sig(block, **kwargs):
     # For RichTextBlock add the features to the signature
     if isinstance(block, RichTextBlock) and getattr(block, 'features', None):
         csig = csig + (tuple(block.features),)
+
+    # For PageChooserBlock add the page types to the signature
+    elif isinstance(block, PageChooserBlock) and getattr(block, 'target_model', None):
+        csig = csig + (tuple(block.target_model) if isinstance(block.target_model, (tuple, list)) else (block.target_model,))
     
     return csig
 

--- a/wagtail_react_streamfield/blocks/block.py
+++ b/wagtail_react_streamfield/blocks/block.py
@@ -19,8 +19,9 @@ def get_cache_sig(block, **kwargs):
     '''
     parent_block = kwargs.get('parent_block')
     help_text = getattr(block.meta, 'help_text', None)
-    return (block.name, type(parent_block), type(block), help_text) if parent_block \
-        else (block.name, type(block), help_text)
+    icon = getattr(block.meta, 'icon', None)
+    return (block.name, type(parent_block), type(block), icon, help_text) if parent_block \
+        else (block.name, type(block), icon, help_text)
 
 
 class NewBlock(Block):

--- a/wagtail_react_streamfield/blocks/field_block.py
+++ b/wagtail_react_streamfield/blocks/field_block.py
@@ -32,7 +32,7 @@ class NewFieldBlock(FieldBlock):
                 value, prefix=Block.FIELD_NAME_TEMPLATE, errors=errors)
         return data
 
-    def get_definition(self):
+    def get_definition(self, **kwargs):
         definition = super(FieldBlock, self).get_definition()
         definition['html'] = self.render_form(self.get_default(),
                                               prefix=self.FIELD_NAME_TEMPLATE)

--- a/wagtail_react_streamfield/blocks/static_block.py
+++ b/wagtail_react_streamfield/blocks/static_block.py
@@ -2,7 +2,7 @@ from wagtail.core.blocks import StaticBlock, Block
 
 
 class NewStaticBlock(StaticBlock):
-    def get_definition(self):
+    def get_definition(self, **kwargs):
         definition = Block.get_definition(self)
         definition.update(
             isStatic=True,

--- a/wagtail_react_streamfield/blocks/stream_block.py
+++ b/wagtail_react_streamfield/blocks/stream_block.py
@@ -1,17 +1,31 @@
+import logging, datetime
 from uuid import uuid4
 
 from wagtail.core.blocks import BaseStreamBlock, StreamValue
 
 from ..exceptions import RemovedError
 
+from .block import BLOCK_CACHE, get_cache_sig
+
+logger = logging.getLogger(__name__)
+
 
 class NewBaseStreamBlock(BaseStreamBlock):
-    def get_definition(self):
+    
+    def get_definition(self, **kwargs):
+
+        # Check cache for rendered definition of the block
+        csig = get_cache_sig(self, **kwargs)
+        if BLOCK_CACHE.get(csig):
+            return BLOCK_CACHE.get(csig)
+        
+        logger.debug('Prepare definition of stream field block %s (%s): %s' 
+            % (self.name, type(self), datetime.datetime.utcnow()))
+
         definition = super(BaseStreamBlock, self).get_definition()
         definition.update(
             children=[
-                child_block.get_definition()
-                for child_block in self.child_blocks.values()
+                child_block.get_definition(parent_block=self) for child_block in self.child_blocks.values()
             ],
             minNum=self.meta.min_num,
             maxNum=self.meta.max_num,
@@ -19,6 +33,9 @@ class NewBaseStreamBlock(BaseStreamBlock):
         html = self.get_blocks_container_html()
         if html is not None:
             definition['html'] = html
+
+        # Cache definition of block
+        BLOCK_CACHE[csig] = definition
         return definition
 
     def sorted_child_blocks(self):
@@ -39,13 +56,14 @@ class NewBaseStreamBlock(BaseStreamBlock):
     def value_from_datadict(self, data, files, prefix):
         return StreamValue(self, [
             (child_block_data['type'],
-             self.child_blocks[child_block_data['type']].value_from_datadict(
-                 child_block_data, files, prefix,
-             ),
-             child_block_data.get('id', str(uuid4())))
+            self.child_blocks[child_block_data['type']].value_from_datadict(
+                child_block_data, files, prefix,
+            ),
+            child_block_data.get('id', str(uuid4())))
             for child_block_data in data['value']
             if child_block_data['type'] in self.child_blocks
         ])
+
 
     def prepare_for_react(self, parent_block, value,
                           type_name=None, errors=None):
@@ -60,10 +78,12 @@ class NewBaseStreamBlock(BaseStreamBlock):
             return []
         children_errors = ({} if errors is None
                            else errors.as_data()[0].params)
-        return [
+        val = [
             child_block_data.block.prepare_for_react(
                 self, child_block_data, errors=children_errors.get(i))
             for i, child_block_data in enumerate(value)]
+        
+        return val
 
     def value_omitted_from_data(self, data, files, prefix):
         return data.get('value') is None

--- a/wagtail_react_streamfield/blocks/struct_block.py
+++ b/wagtail_react_streamfield/blocks/struct_block.py
@@ -17,7 +17,7 @@ class NewBaseStructBlock(BaseStructBlock):
 
         self.dependencies = self.child_blocks.values()
 
-    def get_definition(self):
+    def get_definition(self, **kwargs):
         definition = super(BaseStructBlock, self).get_definition()
         definition.update(
             isStruct=True,

--- a/wagtail_react_streamfield/edit_handlers.py
+++ b/wagtail_react_streamfield/edit_handlers.py
@@ -1,6 +1,12 @@
+import logging, datetime
+
 from wagtail.admin.edit_handlers import StreamFieldPanel
+from guru.helpers.utils.object import pick
+
+logger = logging.getLogger(__name__)
 
 
 class NewStreamFieldPanel(StreamFieldPanel):
+    
     def html_declarations(self):
         return ''

--- a/wagtail_react_streamfield/edit_handlers.py
+++ b/wagtail_react_streamfield/edit_handlers.py
@@ -10,3 +10,23 @@ class NewStreamFieldPanel(StreamFieldPanel):
     
     def html_declarations(self):
         return ''
+
+
+class BlockCacheStreamFieldPanel(NewStreamFieldPanel):
+    ''' StreamField panel instance which uses a block cache to improve performance of page load
+    '''
+    def __init__(self, *args, **kwargs):
+        super(BlockCacheStreamFieldPanel, self).__init__(*args, **kwargs)
+
+    def on_instance_bound(self, *args, **kwargs):
+        
+        # Initialize new block cache
+        if not hasattr(self, 'block_cache'):
+            logger.debug('Initialize block cache')
+            setattr(self, 'block_cache', kwargs.get('block_cache') or {})
+        
+        # Initialize block definition for the panel
+        super(BlockCacheStreamFieldPanel, self).on_instance_bound(*args, **kwargs)
+
+        # Attach block cache to root block definition
+        setattr(self.block_def, 'block_cache', self.block_cache)

--- a/wagtail_react_streamfield/monkey_patch.py
+++ b/wagtail_react_streamfield/monkey_patch.py
@@ -67,7 +67,7 @@ def patch():
                 'prepare_for_react', 'prepare_value', 'get_layout',
                 'get_blocks_container_html', 'get_definition',
                 'html_declarations', 'all_html_declarations')
-    _patch_with(BaseStreamBlock, NewBaseStreamBlock,
+    _patch_with(BaseStreamBlock, NewBaseStreamBlock, 
                 'get_definition', 'sorted_child_blocks', 'render_list_member',
                 'html_declarations', 'js_initializer', 'prepare_for_react',
                 'prepare_value', 'render_form', 'value_from_datadict',


### PR DESCRIPTION
This merge request provides an optional cache for block definitions. For complex stream fields with deeply nested blocks, this can speed up the load of the page editor (Wagtail admin) by one or two orders of magnitudes. The cache is enabled by using a `BlockCacheStreamFieldPanel`. The cache is created on the the binding of the model instance to the page/streamfield, and resets between page loads.

We have tested the system in two production systems, and have not yet seen any errors with other Wagtail React StreamField functionality: errors, notifications, and values work as expected.

The block definition hashing is controlled by the type of block, the icon, help text, and features (for rich text fields). I'm sure a more robust signature method will probably be needed at some point, but this is working well for our current use-cases.