### PR TITLE
feat: Allow React Streamfield to work with >=3 Django

### DIFF
--- a/wagtail_react_streamfield/monkey_patch.py
+++ b/wagtail_react_streamfield/monkey_patch.py
@@ -1,4 +1,4 @@
-from django.utils.six import wraps
+from six import wraps
 from wagtail.core.blocks import (
     BlockField, Block, BaseStreamBlock, ListBlock, BaseStructBlock, FieldBlock,
     StaticBlock)

--- a/wagtail_react_streamfield/monkey_patch.py
+++ b/wagtail_react_streamfield/monkey_patch.py
@@ -1,4 +1,5 @@
-from six import wraps
+from functools import wraps
+
 from wagtail.core.blocks import (
     BlockField, Block, BaseStreamBlock, ListBlock, BaseStructBlock, FieldBlock,
     StaticBlock)


### PR DESCRIPTION
As others have noticed, using the Streamfield and django >= 3 no longer supports django.utils.six.

Solves: https://github.com/wagtail/wagtail-react-streamfield/issues/55